### PR TITLE
WARNING in ./node_modules/vis/dist/img/network/zoomExtends.png

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,13 +46,21 @@ var config = {
         test: /.*\.png$/i,
         loaders: [ 'file-loader', {
           loader: 'image-webpack-loader',
-          query: {
+        query: {
+          mozjpeg: {
             progressive: true,
-            pngquant: {
-              quality: '65-90',
-              speed: 4
-            }
-          }
+          },
+          gifsicle: {
+            interlaced: false,
+          },
+          optipng: {
+            optimizationLevel: 4,
+          },
+          pngquant: {
+            quality: '65-90',
+            speed: 4,
+          },
+        }
         }
       ]
       }


### PR DESCRIPTION
WARNING in ./node_modules/vis/dist/img/network/zoomExtends.png
(Emitted value instead of an instance of Error) DEPRECATED. Configure mozjpeg's progressive option in its own options. (mozjpeg.progressive)
 @ ./node_modules/css-loader!./node_modules/vis/dist/vis-network.min.css 7:14765-14805
 @ ./node_modules/vis/dist/vis-network.min.css
 @ ./src/app.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 ./app.js 


so i follow this issue : 
https://github.com/tcoopman/image-webpack-loader/issues/68 & change 

```
 query: {
            progressive: true,
            pngquant: {
              quality: '65-90',
              speed: 4
            }
          }
```